### PR TITLE
fix pb_module name in typings

### DIFF
--- a/priv/grpcbox_service_bhvr.erl
+++ b/priv/grpcbox_service_bhvr.erl
@@ -9,7 +9,7 @@
 
 {{#methods}}
 %% @doc {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
--callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:ctx(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
-    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:ctx()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
+-callback {{method}}({{^input_stream}}{{#output_stream}}'{{pb_module}}':{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:ctx(), '{{pb_module}}':{{input}}(){{/output_stream}}{{/input_stream}}) ->
+    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, '{{pb_module}}':{{output}}(), ctx:ctx()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
 
 {{/methods}}

--- a/priv/grpcbox_service_client.erl
+++ b/priv/grpcbox_service_client.erl
@@ -25,20 +25,20 @@
 
 {{#methods}}
 %% @doc {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
--spec {{method}}({{^input_stream}}{{pb_module}}:{{input}}(){{/input_stream}}) ->
-    {{^output_stream}}{{^input_stream}}{ok, {{pb_module}}:{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
+-spec {{method}}({{^input_stream}}'{{pb_module}}':{{input}}(){{/input_stream}}) ->
+    {{^output_stream}}{{^input_stream}}{ok, '{{pb_module}}':{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
 {{method}}({{^input_stream}}Input{{/input_stream}}) ->
     {{method}}(ctx:new(){{^input_stream}}, Input{{/input_stream}}, #{}).
 
--spec {{method}}(ctx:t(){{^input_stream}} | {{pb_module}}:{{input}}(){{/input_stream}}{{^input_stream}}, {{pb_module}}:{{input}}(){{/input_stream}} | grpcbox_client:options()) ->
-    {{^output_stream}}{{^input_stream}}{ok, {{pb_module}}:{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
+-spec {{method}}(ctx:t(){{^input_stream}} | '{{pb_module}}':{{input}}(){{/input_stream}}{{^input_stream}}, '{{pb_module}}':{{input}}(){{/input_stream}} | grpcbox_client:options()) ->
+    {{^output_stream}}{{^input_stream}}{ok, '{{pb_module}}':{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
 {{method}}(Ctx{{^input_stream}}, Input{{/input_stream}}) when ?is_ctx(Ctx) ->
     {{method}}(Ctx{{^input_stream}}, Input{{/input_stream}}, #{});
 {{method}}({{^input_stream}}Input, {{/input_stream}}Options) ->
     {{method}}(ctx:new(){{^input_stream}}, Input{{/input_stream}}, Options).
 
--spec {{method}}(ctx:t(){{^input_stream}}, {{pb_module}}:{{input}}(){{/input_stream}}, grpcbox_client:options()) ->
-    {{^output_stream}}{{^input_stream}}{ok, {{pb_module}}:{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
+-spec {{method}}(ctx:t(){{^input_stream}}, '{{pb_module}}':{{input}}(){{/input_stream}}, grpcbox_client:options()) ->
+    {{^output_stream}}{{^input_stream}}{ok, '{{pb_module}}':{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
 {{method}}(Ctx{{^input_stream}}, Input{{/input_stream}}, Options) ->
     {{^output_stream}}{{^input_stream}}grpcbox_client:unary(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, Input, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{#input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, Input, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{#input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{/output_stream}}.
 


### PR DESCRIPTION
If protofile name contains illegal characters for module name then we should wrap pb module name in single quotes in all typings