### PR TITLE
Service template changes associated with non spawned handlers

### DIFF
--- a/priv/grpcbox_service_bhvr.erl
+++ b/priv/grpcbox_service_bhvr.erl
@@ -10,6 +10,9 @@
 {{#methods}}
 %% @doc {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
 -callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:ctx(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
-    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:ctx()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
-
+    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:ctx()}{{/output_stream}}{{#output_stream}} | {ok, grpcbox_stream:t()}{{/output_stream}}{{#output_stream}} | {ok, {{pb_module}}:{{output}}(), grpcbox_stream:t()}{{/output_stream}}{{#output_stream}} | {stop, grpcbox_stream:t()}{{/output_stream}}{{#output_stream}} | {stop, {{pb_module}}:{{output}}(), grpcbox_stream:t()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
 {{/methods}}
+
+-callback init(atom(), grpcbox_stream:t()) -> grpcbox_stream:t().
+-callback handle_info(any(), grpcbox_stream:t()) -> grpcbox_stream:t().
+-optional_callbacks([init/2, handle_info/2]).


### PR DESCRIPTION
Linked grpcbox PR:  https://github.com/tsloughter/grpcbox/pull/52

Change Summary
-----------------

1.  Support additional response payloads for streaming RPCs, new example:

    ok
    | {ok, grpcbox_stream:t()}
    | {ok, ResponseMsg, grpcbox_stream:t()}
    | {stop, grpcbox_stream:t()}
    | {stop, ResponseMsg, grpcbox_stream:t()}
    | grpcbox_stream:grpc_error_response().

2.  Adds init/1 and handle_info/2 callbacks to service behaviour template
