### PR TITLE
strip out build date from templates for deterministic builds

### DIFF
--- a/priv/grpcbox_service_bhvr.erl
+++ b/priv/grpcbox_service_bhvr.erl
@@ -3,7 +3,7 @@
 %% @end
 %%%-------------------------------------------------------------------
 
-%% this module was generated on {{datetime}} and should not be modified manually
+%% this module was generated and should not be modified manually
 
 -module({{module_name}}_bhvr).
 

--- a/priv/grpcbox_service_client.erl
+++ b/priv/grpcbox_service_client.erl
@@ -3,7 +3,7 @@
 %% @end
 %%%-------------------------------------------------------------------
 
-%% this module was generated on {{datetime}} and should not be modified manually
+%% this module was generated and should not be modified manually
 
 -module({{module_name}}_client).
 


### PR DESCRIPTION
Fixes #12 

Templates use [this code for generation](https://github.com/erlang/rebar3/blob/c5176e34437a905f91541560bb327fe3be38c065/src/rebar_templater.erl#L112-L114):

```erlang
    {{Y,M,D},{H,Min,S}} = calendar:universal_time(),
    [{date, lists:flatten(io_lib:format("~4..0w-~2..0w-~2..0w",[Y,M,D]))},
     {datetime, lists:flatten(io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w+00:00",[Y,M,D,H,Min,S]))},
```

I haven't been able to find a way to override this value with a simple flag or env var. Maybe `faketime` can be a workaround.

For simplicity of use and because generated files' mtime is usually tracked by the SCM (e.g. git) I just stripped the dates out.