### PR TITLE
Template doc and type fixes

### DIFF
--- a/priv/grpcbox_service_bhvr.erl
+++ b/priv/grpcbox_service_bhvr.erl
@@ -8,7 +8,7 @@
 -module({{module_name}}_bhvr).
 
 {{#methods}}
-%% @doc {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
+%% {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
 -callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:ctx(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
     {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:ctx()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
 

--- a/priv/grpcbox_service_bhvr.erl
+++ b/priv/grpcbox_service_bhvr.erl
@@ -9,7 +9,7 @@
 
 {{#methods}}
 %% {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
--callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:ctx(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
-    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:ctx()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
+-callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:t(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
+    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:t()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
 
 {{/methods}}


### PR DESCRIPTION
This fixes two issues with the templates in two commits. Let me know if you would rather like these as two separate PRs. I thought there may potentially be merge conflicts since they touch adjacent lines, so to start with, I've put them as two commits in sequence.

I'll try to illustrate the problems I'm attempting to address, using the grpcbox. I know routeguide_route_guide_bhvr.erl in that repo is a git-controlled file and not generated, so the example is admittedly a bit contrived, but nevertheless shows one of the issues.

The first commit removes `@doc` from the generated behaviour files since this seems to not be valid edoc:
```
$ cd _build/test/lib/grpcbox/test/
$ erl
1> edoc:file("routeguide_route_guide_bhvr.erl").
routeguide_route_guide_bhvr.erl, in module footer: at line 10: tag @doc not allowed here.
routeguide_route_guide_bhvr.erl, in module footer: at line 14: multiple @doc tag.
routeguide_route_guide_bhvr.erl, in module footer: at line 18: multiple @doc tag.
routeguide_route_guide_bhvr.erl, in module footer: at line 22: multiple @doc tag.
routeguide_route_guide_bhvr.erl, in module footer: at line 26: multiple @doc tag.
routeguide_route_guide_bhvr.erl, in module footer: at line 30: multiple @doc tag.

```

The second commit fixes the `ctx` type reference  in the generated code: `ctx:ctx()` ⟶ `ctx:t()`


This is with Erlang 24.3.4.